### PR TITLE
🐛 fix: 가게 대시보드 조회 로직 KST 기준으로 수정 및 주석 보완

### DIFF
--- a/src/main/java/com/example/finalproject/domain/stores/repository/StoreDashboardRepository.java
+++ b/src/main/java/com/example/finalproject/domain/stores/repository/StoreDashboardRepository.java
@@ -23,39 +23,39 @@ public interface StoreDashboardRepository extends JpaRepository<com.example.fina
 
     /**
      * [일/월 버킷 집계] 주문 수 & 매출 (완료 상태 기준)
-     * - 시간 비교: UTC 경계 (fromUtc <= created_at < toUtc)
-     * - 버킷 표시: SELECT 단계에서만 KST(+09:00) 변환 → 라벨링 전용
-     *   - grain='day'   → YYYY-MM-DD
-     *   - grain='month' → YYYY-MM
+     * - 기준: 주문 created_at (KST 로컬시각)
+     * - 버킷 표시:
+     *   - grain='day'   → DATE(created_at)
+     *   - grain='month' → DATE_FORMAT(created_at, '%Y-%m')
+     * - 기간 조건: DATE(created_at) BETWEEN :fromDate AND :toDate
      */
     @Query(value = """
         SELECT
           CASE WHEN :grain = 'month'
-               THEN DATE_FORMAT(CONVERT_TZ(o.created_at, '+00:00', '+09:00'), '%Y-%m')
-               ELSE DATE(CONVERT_TZ(o.created_at, '+00:00', '+09:00'))
+               THEN DATE_FORMAT(o.created_at, '%Y-%m')   -- 월 버킷
+               ELSE DATE(o.created_at)                   -- 일 버킷
           END AS bucket,
-          COUNT(*) AS orders,
-          COALESCE(SUM(o.total_price), 0) AS revenue
+          COUNT(*)                        AS orders,
+          COALESCE(SUM(o.total_price),0)  AS revenue
         FROM orders o
         WHERE o.store_id = :storeId
-          AND o.status = 'COMPLETED'
-          AND o.created_at >= :fromUtc
-          AND o.created_at <  :toUtc
+          AND o.status   = 'COMPLETED'
+          AND DATE(o.created_at) BETWEEN :fromDate AND :toDate
         GROUP BY bucket
         ORDER BY bucket
     """, nativeQuery = true)
     List<OrderBucketRow> aggregateOrdersAndRevenue(
             @Param("storeId") Long storeId,
-            @Param("fromUtc") String fromUtc,
-            @Param("toUtc")   String toUtc,
-            @Param("grain")   String grain
+            @Param("fromDate") String fromDate, // yyyy-MM-dd (KST 달력 날짜)
+            @Param("toDate")   String toDate,   // yyyy-MM-dd (KST 달력 날짜)
+            @Param("grain")    String grain
     );
 
     /**
      * [요약] 주문 수 / 총 매출 / AOV
-     * - 시간 비교: UTC 경계
+     * - 기준: 주문 created_at (KST 로컬시각)
+     * - 기간 조건: DATE(created_at) BETWEEN :fromDate AND :toDate
      * - AOV(평균 객단가): revenue / orders
-     *   - orders=0인 경우 NULL → ROUND(NULL)로 안전 처리됨
      */
     @Query(value = """
         SELECT
@@ -64,20 +64,20 @@ public interface StoreDashboardRepository extends JpaRepository<com.example.fina
           ROUND(COALESCE(SUM(o.total_price),0) / NULLIF(COUNT(*),0)) AS aov
         FROM orders o
         WHERE o.store_id = :storeId
-          AND o.status = 'COMPLETED'
-          AND o.created_at >= :fromUtc
-          AND o.created_at <  :toUtc
+          AND o.status   = 'COMPLETED'
+          AND DATE(o.created_at) BETWEEN :fromDate AND :toDate
     """, nativeQuery = true)
     List<SummaryRow> summary(@Param("storeId") Long storeId,
-                             @Param("fromUtc") String fromUtc,
-                             @Param("toUtc")   String toUtc);
+                             @Param("fromDate") String fromDate,
+                             @Param("toDate")   String toDate);
+
 
     /**
      * [인기 메뉴 Top-N]
      * - 기준: 판매 수량 DESC → 동률 시 매출 DESC
-     * - 시간 비교: UTC 경계
-     * - 주의: 매출 계산은 `m.price` 현재값을 사용
-     *         → 과거 주문 시점의 단가를 반영하려면 `order_items.unit_price` 사용 권장
+     * - 기간 조건: DATE(created_at) BETWEEN :fromDate AND :toDate
+     * - 매출 계산은 메뉴 현재 단가(m.price) 사용
+     *   (과거 주문 시점 단가 반영 필요시 order_items.unit_price 사용 권장)
      */
     @Query(value = """
         SELECT
@@ -89,73 +89,71 @@ public interface StoreDashboardRepository extends JpaRepository<com.example.fina
         JOIN order_items oi ON oi.order_id = o.id
         JOIN menus m        ON m.id = oi.menu_id
         WHERE o.store_id = :storeId
-          AND o.status = 'COMPLETED'
-          AND o.created_at >= :fromUtc
-          AND o.created_at <  :toUtc
+          AND o.status   = 'COMPLETED'
+          AND DATE(o.created_at) BETWEEN :fromDate AND :toDate
         GROUP BY oi.menu_id
         ORDER BY quantity DESC, revenue DESC
         LIMIT :limit
     """, nativeQuery = true)
     List<TopMenuRow> topMenus(@Param("storeId") Long storeId,
-                              @Param("fromUtc") String fromUtc,
-                              @Param("toUtc")   String toUtc,
-                              @Param("limit")   int limit);
+                              @Param("fromDate") String fromDate,
+                              @Param("toDate")   String toDate,
+                              @Param("limit")    int limit);
 
     /**
      * [리뷰 통계] 평균 평점 & 리뷰 개수
-     * - 조건: 삭제되지 않은 리뷰(is_deleted=FALSE)만 포함
-     * - 시간 비교: UTC 경계
-     * - 평점 평균: 소수점 둘째 자리까지 반올림
+     * - 기준: 리뷰 created_at (KST 로컬시각)
+     * - 조건: is_deleted = FALSE
+     * - 기간 조건: DATE(created_at) BETWEEN :fromDate AND :toDate
+     * - 평균 평점: 소수점 둘째 자리까지 반올림
      */
     @Query(value = """
         SELECT
           ROUND(AVG(r.rating), 2) AS avgRating,
           COUNT(*)                AS count
         FROM reviews r
-        WHERE r.store_id = :storeId
+        WHERE r.store_id   = :storeId
           AND r.is_deleted = FALSE
-          AND r.created_at >= :fromUtc
-          AND r.created_at <  :toUtc
+          AND DATE(r.created_at) BETWEEN :fromDate AND :toDate
     """, nativeQuery = true)
     List<ReviewRow> reviewStats(@Param("storeId") Long storeId,
-                                @Param("fromUtc") String fromUtc,
-                                @Param("toUtc")   String toUtc);
+                                @Param("fromDate") String fromDate,
+                                @Param("toDate")   String toDate);
 
     /**
      * [고유 고객 수]
-     * - 특정 기간 내 COMPLETED 주문을 가진 서로 다른 사용자 수
-     * - 시간 비교: UTC 경계
+     * - 기준: 특정 기간 내 COMPLETED 주문이 있는 서로 다른 user_id 수
+     * - 기간 조건: DATE(created_at) BETWEEN :fromDate AND :toDate
      */
     @Query(value = """
         SELECT COUNT(DISTINCT o.user_id) AS uniq
         FROM orders o
         WHERE o.store_id = :storeId
-          AND o.status = 'COMPLETED'
-          AND o.created_at >= :fromUtc
-          AND o.created_at <  :toUtc
+          AND o.status   = 'COMPLETED'
+          AND DATE(o.created_at) BETWEEN :fromDate AND :toDate
     """, nativeQuery = true)
     Long uniqueCustomers(@Param("storeId") Long storeId,
-                         @Param("fromUtc") String fromUtc,
-                         @Param("toUtc")   String toUtc);
+                         @Param("fromDate") String fromDate,
+                         @Param("toDate")   String toDate);
+
 
     /**
      * [재방문 고객 수]
-     * - 특정 기간 내 COMPLETED 주문을 2회 이상 가진 사용자 수
-     * - 시간 비교: UTC 경계
+     * - 기준: 특정 기간 내 COMPLETED 주문이 2회 이상인 사용자 수
+     * - 기간 조건: DATE(created_at) BETWEEN :fromDate AND :toDate
      */
     @Query(value = """
         SELECT COUNT(*) FROM (
           SELECT o.user_id
           FROM orders o
           WHERE o.store_id = :storeId
-            AND o.status = 'COMPLETED'
-            AND o.created_at >= :fromUtc
-            AND o.created_at <  :toUtc
+            AND o.status   = 'COMPLETED'
+            AND DATE(o.created_at) BETWEEN :fromDate AND :toDate
           GROUP BY o.user_id
           HAVING COUNT(*) >= 2
         ) t
     """, nativeQuery = true)
     Long repeatCustomers(@Param("storeId") Long storeId,
-                         @Param("fromUtc") String fromUtc,
-                         @Param("toUtc")   String toUtc);
+                         @Param("fromDate") String fromDate,
+                         @Param("toDate")   String toDate);
 }

--- a/src/main/java/com/example/finalproject/domain/stores/service/StoreDashboardService.java
+++ b/src/main/java/com/example/finalproject/domain/stores/service/StoreDashboardService.java
@@ -20,7 +20,6 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 
@@ -35,32 +34,44 @@ public class StoreDashboardService {
 
     /**
      * [가게 대시보드 조회]
-     * - 기간/단위별 집계 데이터를 조회하고 응답 DTO 구성
      * ---------------------------------------------------
      * 처리 단계:
      * (0) 파라미터 검증
-     *      - grain: day | month
+     *      - grain: "day" | "month"
      *      - from <= to
+     *      - 기본값: (to=오늘, from=to-30일)
      * (1) 현재 로그인 사용자 조회
-     *      - Spring SecurityContextHolder → email → Users 엔티티
+     *      - SecurityContextHolder → email → Users 엔티티
      * (2) 가게 소유권 검증
      *      - owner_id == 로그인 사용자 id
      * (3) 기간 경계 변환
      *      - 입력: KST(LocalDate)
-     *      - 처리: 자정 기준 ZonedDateTime → UTC 문자열
-     * (4) 시계열 (orders/revenue by bucket)
-     * (5) 요약 통계 (orders/revenue/AOV)
+     *      - 변환: 그대로 yyyy-MM-dd 문자열 사용
+     *      - DB created_at 컬럼이 이미 KST 시각으로 저장되므로
+     *        UTC 변환 불필요
+     * (4) 시계열 데이터 (orders/revenue by bucket)
+     *      - grain=day   → YYYY-MM-DD
+     *      - grain=month → YYYY-MM
+     * (5) 요약 통계 (orders, revenue, AOV)
      * (6) 인기 메뉴 Top-N
-     *      - 주의: 매출 계산 시 메뉴 현재 단가 사용
+     *      - 매출 계산: 메뉴 현재 단가(m.price) 기준
      * (7) 리뷰 통계 (avgRating, count)
      * (8) 고객 통계 (unique, repeat, repeatRate%)
      * (9) 응답 DTO 구성
+     *      - range / series / summary / topMenus / reviews / customers
      */
     public StoreDashboardResponse getDashboard(Long storeId, LocalDate from, LocalDate to, String grain, int topN) {
         // (0) 파라미터 검증
         if (!"day".equals(grain) && !"month".equals(grain)) {
             throw new ApiException(ErrorCode.BAD_REQUEST, "grain은 day 또는 month만 허용됩니다.");
         }
+
+        // 기본값: to가 null 이면 오늘(KST), from이 null 이면 to-30일
+        ZoneId KST = ZoneId.of("Asia/Seoul");
+        LocalDate todayKst = ZonedDateTime.now(KST).toLocalDate();
+        to   = (to   == null) ? todayKst : to;
+        from = (from == null) ? to.minusDays(30) : from;
+
         if (from.isAfter(to)) {
             throw new ApiException(ErrorCode.BAD_REQUEST, "from은 to보다 이후일 수 없습니다.");
         }
@@ -71,22 +82,17 @@ public class StoreDashboardService {
         Users me = usersRepository.findByEmail(email)
                 .orElseThrow(() -> new ApiException(ErrorCode.UNAUTHORIZED, "로그인 정보를 확인해 주세요."));
 
-        // (2) 소유권 검증 (본인 소유 가게만 접근 허용)
+        // (2) 소유권 검증
         if (!storesRepository.existsByIdAndOwner_Id(storeId, me.getId())) {
             throw new ApiException(ErrorCode.FORBIDDEN, "본인 소유 가게만 조회할 수 있습니다.");
         }
 
-        // (3) 기간 경계 변환: KST → UTC
-        ZoneId KST = ZoneId.of("Asia/Seoul");
-        ZoneId UTC = ZoneId.of("UTC");
-        LocalDate toExclusive = to.plusDays(1); // to 일의 자정 다음날 → exclusive 범위
-        DateTimeFormatter FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-
-        String fromUtc = ZonedDateTime.of(from.atStartOfDay(), KST).withZoneSameInstant(UTC).format(FMT);
-        String toUtc   = ZonedDateTime.of(toExclusive.atStartOfDay(), KST).withZoneSameInstant(UTC).format(FMT);
+        // (3) 기간 경계 생성
+        String fromDate = from.toString();
+        String toDate   = to.toString();
 
         // (4) 시계열 데이터 조회 (일/월 bucket 기준)
-        List<OrderBucketRow> rows = dashboardRepository.aggregateOrdersAndRevenue(storeId, fromUtc, toUtc, grain);
+        List<OrderBucketRow> rows = dashboardRepository.aggregateOrdersAndRevenue(storeId, fromDate, toDate, grain);
         List<StoreDashboardResponse.Point> series = rows.stream()
                 .map(r -> new StoreDashboardResponse.Point(
                         r.getBucket(),
@@ -96,14 +102,14 @@ public class StoreDashboardService {
                 .toList();
 
         // (5) 요약 통계 조회 (orders, revenue, AOV)
-        List<SummaryRow> sumList = dashboardRepository.summary(storeId, fromUtc, toUtc);
+        List<SummaryRow> sumList = dashboardRepository.summary(storeId, fromDate, toDate);
         SummaryRow sum = sumList.isEmpty() ? null : sumList.get(0);
         long totalOrders = (sum == null) ? 0L : safeLong(sum.getOrders());
         long revenue     = (sum == null) ? 0L : safeLong(sum.getRevenue());
         long aov         = (sum == null) ? 0L : safeLong(sum.getAov());
 
-        // (6) 인기 메뉴 Top-N
-        List<TopMenuRow> top = dashboardRepository.topMenus(storeId, fromUtc, toUtc, topN);
+        // (6) 인기 메뉴 Top-N 조회
+        List<TopMenuRow> top = dashboardRepository.topMenus(storeId, fromDate, toDate, topN);
         List<Map<String, Object>> topMenus = top.stream().map(r -> Map.<String, Object>of(
                 "menuId",   safeLong(r.getMenuId()),
                 "name",     r.getName(),
@@ -112,14 +118,14 @@ public class StoreDashboardService {
         )).toList();
 
         // (7) 리뷰 통계 조회 (평균 평점, 리뷰 개수)
-        List<ReviewRow> rvList = dashboardRepository.reviewStats(storeId, fromUtc, toUtc);
+        List<ReviewRow> rvList = dashboardRepository.reviewStats(storeId, fromDate, toDate);
         ReviewRow rv = rvList.isEmpty() ? null : rvList.get(0);
         double avgRating = (rv == null || rv.getAvgRating() == null) ? 0.0 : rv.getAvgRating();
         long reviewCount = (rv == null) ? 0L : safeLong(rv.getCount());
 
-        // (8) 고객 통계 조회 (고유 고객 수, 재방문 고객 수, 재방문율%)
-        long uniq = safeLong(dashboardRepository.uniqueCustomers(storeId, fromUtc, toUtc));
-        long rep  = safeLong(dashboardRepository.repeatCustomers(storeId, fromUtc, toUtc));
+        // (8) 고객 통계 조회
+        long uniq = safeLong(dashboardRepository.uniqueCustomers(storeId, fromDate, toDate));
+        long rep  = safeLong(dashboardRepository.repeatCustomers(storeId, fromDate, toDate));
         double repeatRate = (uniq == 0) ? 0.0 : round2((double) rep * 100.0 / (double) uniq);
 
         // (9) 응답 DTO 구성
@@ -149,7 +155,7 @@ public class StoreDashboardService {
         return res;
     }
 
-    // ---- 유틸리티 (null 안전 처리) ----
+    // ---- 유틸리티 ----
     /** null → 0 변환 & Number → long 캐스팅 */
     private static long safeLong(Object o) {
         if (o == null) return 0L;


### PR DESCRIPTION
- StoreDashboardService: LocalDate(KST) 기반 기간 경계 생성, UTC 변환 제거
- StoreDashboardRepository: created_at을 KST 기준으로 직접 조회하도록 변경
- 각 단계별 처리 로직에 상세 주석 추가 (사용자 검증, 소유권 확인, 통계 조회, DTO 구성)
- 리뷰/고객 통계 및 인기 메뉴 Top-N 조회 시 KST 날짜 조건 적용